### PR TITLE
docs(context): add 3-tier progressive disclosure documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.5.0] - 2026-01-27
+
+### Added
+
+- Bytes/Chars/Words count mode toggle
+- "Last synced" timestamp indicator
+- OSS documentation: LICENSE, CONTRIBUTING.md, SECURITY.md, PR template
+- .gitignore rule for macOS .DS_Store files
+
+### Changed
+
+- Bump version to 2.5.0
+
+### Fixed
+
+- Label usage by count mode and separate sync status display
+
+## [2.4.0] - 2026-01-25
+
+### Added
+
+- AGENTS.md for AI coding agent instructions
+- GitHub Actions CI workflow (lint, type check, test on Node 22 + 24)
+- Chrome Web Store publish workflow triggered by version tags
+- Version verification script to ensure package.json and manifest.json match
+
+### Changed
+
+- Replace ESLint with Biome for linting and formatting
+- Replace Jest with Vitest for testing
+- Bump packages to latest
+
 ## [2.3.0] - 2025-03-24
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,47 @@
+@AGENTS.md
+
+<!-- Above imports universal agent instructions. Claude-specific extensions below. -->
+
+## Architecture Quick Reference
+
+- UI page: `src/html/index.html` with logic in `src/main.ts`
+- Service worker: `src/service_worker.ts` (tab management only)
+- Shared utilities: `src/utils.ts` (throttle function)
+- Sync storage key: `v2` in `chrome.storage.sync` (8,192 byte limit)
+- Local storage key: `cursor` in `chrome.storage.local` (cursor position)
+- Throttle: leading-edge, ~4 second delay calculated from `MAX_WRITE_OPERATIONS_PER_HOUR`
+
+## Code Patterns
+
+IIFE pattern: Both `main.ts` and `service_worker.ts` wrap logic in IIFEs that receive `chrome` as a parameter.
+
+Storage writes always use `.then()` / `.catch()` chains (not await), and update UI on success:
+```typescript
+storage.sync.set(storageObject)
+  .then(() => { updateUsage(); updateLastSynced(); })
+  .catch((e: unknown) => { console.warn(e); });
+```
+
+Event listeners are attached imperatively after DOM element lookup with null guards:
+```typescript
+if (copyButtonEl) {
+  copyButtonEl.addEventListener('click', () => { void copyAllText(); });
+}
+```
+
+## Debugging Playbook
+
+1. **Tests fail**: Run `pnpm test` locally. Tests mock Chrome APIs; check mock setup in spec files.
+2. **Lint errors**: Run `pnpm lint:fix`. Biome config is in `biome.json`.
+3. **Build issues**: Check `webpack/webpack.config.cjs`. Uses `tsconfig.build.json` (not `tsconfig.json`).
+4. **Version mismatch**: Both `package.json` and `public/manifest.json` must match. Use `pnpm verify-version`.
+
+## CI/CD Details
+
+- CI runs on PRs: lint, type check, test (Node 22 + 24 matrix)
+- Publish runs on `v*.*.*` tag push: builds + uploads `app.zip` to Chrome Web Store
+- Secrets needed: `CHROME_EXTENSION_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`
+
+## Deep Dives
+
+Full architecture, development workflow, and troubleshooting: docs/KNOWLEDGE_BASE.md

--- a/README.md
+++ b/README.md
@@ -85,14 +85,14 @@ Tag pushes trigger the publish workflow, which builds the extension and uploads
 ## Communication
 
 - Bug reports and feature requests: GitHub Issues
-- Contributions: see `CONTRIBUTING.md`
-- Security reports: see `SECURITY.md`
+- Contributions: see [CONTRIBUTING.md](CONTRIBUTING.md)
+- Security reports: see [SECURITY.md](SECURITY.md)
 
 ## License
 
 This project is licensed under the Creative Commons Attribution-ShareAlike 4.0
-International Public License. See `LICENSE`.
+International Public License. See [LICENSE](LICENSE).
 
 ## Changelog
 
-See `CHANGELOG.md`.
+See [CHANGELOG.md](CHANGELOG.md).

--- a/docs/KNOWLEDGE_BASE.md
+++ b/docs/KNOWLEDGE_BASE.md
@@ -1,0 +1,17 @@
+# Knowledge Base
+
+## Architecture
+Extension components, storage design, sync throttling, build pipeline, and CI/CD workflows.
+-> docs/architecture.md
+
+## Development
+Setup, scripts, local dev loop, testing, linting, TypeScript config, commit conventions, and release process.
+-> docs/development.md
+
+## Troubleshooting
+Common issues (pnpm, nave, stale builds, test failures, sync quota), debugging tips for service worker and UI.
+-> docs/troubleshooting.md
+
+## UX Improvement Plans
+Planned features and UI/UX improvements: save-on-input, clear button, copy all, bytes/chars/words toggle, tab reuse, export, cursor restore, and more.
+-> docs/plans/low-hanging-fruit-and-ux.md

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,121 @@
+# Architecture
+
+## Overview
+
+Write Wall is a Chrome Extension built on Manifest V3. It provides a synced text pad that persists across devices using the signed-in Chrome account. There is no external backend; all persistence uses the Chrome Storage API.
+
+## Extension Components
+
+### UI Page (`src/html/index.html`)
+
+Single HTML page rendered when the extension action icon is clicked. Contains:
+- `<textarea id="text">` - main editing area
+- `#info` bar - byte/char/word counter, sync status, count mode selector, Export/Copy/Clear buttons
+- `<select id="count-mode">` - toggles between Bytes, Chars, Words display
+
+### Main Logic (`src/main.ts`)
+
+Runs in the context of the UI page. Responsibilities:
+- Reads stored text from `chrome.storage.sync` on load (key: `v2`)
+- Migrates legacy storage key `text` to `v2` if found
+- Throttles writes to sync storage to respect Chrome quota limits
+- Updates byte/char/word counter after each sync
+- Displays "last synced" timestamp on successful save
+- Stores cursor position in `chrome.storage.local` (key: `cursor`)
+- Restores cursor position and auto-focuses textarea on load
+- Handles Copy (clipboard API with execCommand fallback), Clear (with confirm), and Export (.txt download)
+- Keyboard shortcuts: Cmd/Ctrl+S for immediate save, Cmd/Ctrl+Shift+C for copy all
+
+### Service Worker (`src/service_worker.ts`)
+
+MV3 background service worker. Single responsibility:
+- Listens for `chrome.action.onClicked`
+- Queries for an existing Write Wall tab; focuses it if found (including switching windows)
+- Creates a new tab if no existing tab is open
+
+### Utilities (`src/utils.ts`)
+
+Exports a generic `throttle` function used by `main.ts` to rate-limit storage writes and cursor position saves.
+
+## Storage Architecture
+
+| Store | Key | Purpose | Quota |
+|-------|-----|---------|-------|
+| `chrome.storage.sync` | `v2` | Synced text content | 8,192 bytes total |
+| `chrome.storage.sync` | `text` (legacy) | Old key, migrated to `v2` on first load | - |
+| `chrome.storage.local` | `cursor` | `{start, end}` cursor position | No sync quota |
+
+### Sync Throttling
+
+Write rate is calculated from Chrome's `MAX_WRITE_OPERATIONS_PER_HOUR` constant:
+```
+CHANGE_DELAY = (MAX_WRITE_OPERATIONS_PER_HOUR / 3600) * 4000
+```
+This yields roughly a 4-second delay between sync writes. The `throttle` utility drops calls during the cooldown window (leading-edge throttle).
+
+`Cmd/Ctrl+S` bypasses the throttle for an immediate save.
+
+## Build Pipeline
+
+### Webpack (`webpack/webpack.config.cjs`)
+
+- **Entry points**: `src/main.ts` and `src/service_worker.ts`
+- **Output**: `dist/` directory with `main.bundle.js` and `service_worker.bundle.js`
+- **Loader**: `ts-loader` using `tsconfig.build.json`
+- **Copy plugin**: copies `public/` (manifest, icons), `src/html/`, `src/css/`, `src/images/` into `dist/`
+- **Mode**: production with inline source maps
+
+### Packaging (`build.cjs`)
+
+After webpack, `build.cjs` uses `adm-zip` to create `app.zip` from `dist/` for Chrome Web Store submission.
+
+## CI/CD
+
+### CI Workflow (`.github/workflows/ci.yml`)
+
+Runs on pull requests. Matrix tests against Node 22 and 24:
+1. Install dependencies (`pnpm install --frozen-lockfile`)
+2. Verify version parity (`pnpm verify-version`)
+3. Lint (`pnpm lint` via Biome)
+4. Type check (`pnpm type:check`)
+5. Test (`pnpm test` via Vitest)
+
+### Publish Workflow (`.github/workflows/publish-extension.yml`)
+
+Triggered by `v*.*.*` tag pushes:
+1. Verify tag version matches `package.json` and `public/manifest.json`
+2. Build extension (`pnpm build`)
+3. Upload `app.zip` to Chrome Web Store via `chrome-extension-upload` action
+4. Requires secrets: `CHROME_EXTENSION_ID`, `CHROME_CLIENT_ID`, `CHROME_CLIENT_SECRET`, `CHROME_REFRESH_TOKEN`
+
+## File Structure
+
+```
+src/
+  main.ts              - UI logic, storage sync, event handlers
+  service_worker.ts    - Tab management on action click
+  utils.ts             - Throttle utility
+  main.spec.ts         - Tests for main.ts
+  service_worker.spec.ts - Tests for service worker
+  utils.spec.ts        - Tests for throttle utility
+  verify-version.spec.ts - Tests for version verification
+  html/index.html      - Extension UI page
+  css/main.css         - Styles (dark theme, CSS variables)
+  images/              - Extension icons (16, 19, 48, 64, 128, 512)
+public/
+  manifest.json        - MV3 manifest (source of truth)
+webpack/
+  webpack.config.cjs   - Build configuration
+scripts/
+  verify-version.cjs   - Checks package.json and manifest.json version parity
+dist/                  - Build output (generated, do not edit)
+```
+
+## CSS Theme
+
+Styles use CSS custom properties for a dark theme:
+- `--bg-top` / `--bg-bottom`: gradient background
+- `--text-main` / `--text-muted`: text colors
+- `--accent` / `--border` / `--hover-bg` / `--hover-text`: interactive element styling
+
+Desktop breakpoint at 1024px sets `max-width: 900px` on the textarea.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,112 @@
+# Development Guide
+
+## Prerequisites
+
+- **Node.js**: ^22.0.0 or ^24.0.0 (use `nave`, not `nvm`; see `.naverc`)
+- **pnpm**: Use corepack (`corepack enable`), do not install via npm
+- **Chrome**: For manual testing via `chrome://extensions`
+
+## Setup
+
+```bash
+nave use        # activates the Node version from .naverc
+pnpm install    # install dependencies
+```
+
+## Scripts
+
+| Script | Command | Description |
+|--------|---------|-------------|
+| Develop | `pnpm develop` | Webpack watch mode, rebuilds on change |
+| Build | `pnpm build` | Production webpack build + `app.zip` |
+| Test | `pnpm test` | Run Vitest test suite |
+| Lint | `pnpm lint` | Biome checks (errors only) |
+| Lint fix | `pnpm lint:fix` | Biome auto-fix |
+| Type check | `pnpm type:check` | TypeScript `--noEmit` check |
+| Verify version | `pnpm verify-version` | Ensure package.json and manifest.json match |
+| Prepare | `pnpm prepare` | Install Husky git hooks |
+| Check updates | `pnpm check-updates` | Interactive dependency update check |
+
+## Local Development Loop
+
+1. Run `pnpm develop` to start webpack in watch mode
+2. Open `chrome://extensions`, enable Developer mode
+3. Click "Load unpacked" and select the `dist/` directory
+4. Make changes to `src/` files; webpack rebuilds automatically
+5. Click the reload button on the extension card in `chrome://extensions`
+
+## Testing
+
+Tests use **Vitest** and live alongside source files as `*.spec.ts`:
+- `src/main.spec.ts` - UI logic and storage interactions
+- `src/service_worker.spec.ts` - Tab management behavior
+- `src/utils.spec.ts` - Throttle utility
+- `src/verify-version.spec.ts` - Version parity check
+
+Config: `vitest.config.ts` runs in Node environment with `clearMocks: true`.
+
+Test files use `*.spec.ts` naming (not `*.test.ts`).
+
+## Linting
+
+**Biome** handles formatting and linting. Config in `biome.json`.
+
+Key settings:
+- Indent: 2 spaces, LF line endings
+- Line width: 100
+- Single quotes, trailing commas, semicolons always
+- Excludes: `.github/`, `.husky/`, `.idea/`, `dist/`, `node_modules/`, `*.cjs`, `webpack/`
+
+## TypeScript Configuration
+
+- `tsconfig.json`: Base config, strict mode, target ES2024, ESNext modules
+- `tsconfig.build.json`: Used by ts-loader for webpack builds
+- `tsconfig.test.json`: Used by Vitest
+
+Type definitions: `@types/chrome` for Chrome extension APIs.
+
+## Git Hooks
+
+**Husky** runs on pre-commit:
+- `pnpm lint` - fails commit if linting errors exist
+- `pnpm test` - fails commit if tests fail
+
+## Commit Conventions
+
+All commits follow **Conventional Commits 1.0.0**:
+```
+type(scope)!: subject
+```
+
+- **type** (required): `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `build`, `ci`, `perf`, `style`, `revert`
+- **scope** (optional but recommended)
+- **!** for breaking changes (include `BREAKING CHANGE:` footer)
+- **DCO signoff required**: Always use `git commit -s` or `--signoff`
+
+## Branch and PR Workflow
+
+- All work in feature branches; no direct commits to long-lived branches
+- PRs follow `.github/PULL_REQUEST_TEMPLATE.md`
+- CI runs lint, type check, and tests on PR open/sync/reopen
+- Merge only after review and checks pass
+
+## Release Process
+
+1. Update version in both `package.json` and `public/manifest.json`
+2. Run `pnpm verify-version` to confirm parity
+3. Tag as `vX.Y.Z` and push the tag
+4. Publish workflow builds and uploads `app.zip` to Chrome Web Store
+
+## Adding Code
+
+| What | Where |
+|------|-------|
+| UI behavior / event handlers | `src/main.ts` |
+| Background / tab management | `src/service_worker.ts` |
+| Shared utilities | `src/utils.ts` |
+| Styles | `src/css/main.css` |
+| HTML structure | `src/html/index.html` |
+| Static assets / icons | `src/images/` |
+| Manifest changes | `public/manifest.json` |
+| Build config | `webpack/webpack.config.cjs` |
+| New test | `src/<module>.spec.ts` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,52 @@
+# Troubleshooting
+
+## Common Issues
+
+### "pnpm: command not found"
+
+Enable corepack first:
+```bash
+corepack enable
+```
+Do **not** install pnpm via npm. The project pins a specific pnpm version via `packageManager` in `package.json`.
+
+### "nave: command not found" or wrong Node version
+
+Install nave globally: `npm install -g nave`. Then use `nave use` in the repo root. The `.naverc` file defines the required Node version.
+
+Do **not** use `nvm` for this project.
+
+### Build output is stale after changes
+
+Webpack watch mode (`pnpm develop`) rebuilds on file changes, but you must still manually reload the extension in `chrome://extensions`. Click the reload icon on the Write Wall extension card.
+
+### Tests fail with Chrome API errors
+
+Tests mock `chrome.storage.sync` and related APIs. If a test fails with "chrome is not defined", ensure the test file properly sets up mocks before importing the module under test. The test environment is Node, not a browser.
+
+### Lint errors block commit
+
+Husky pre-commit hook runs `pnpm lint` and `pnpm test`. Fix lint issues with `pnpm lint:fix` before committing. If tests fail, fix the failing test before retrying.
+
+### Version mismatch error
+
+Both `package.json` and `public/manifest.json` must have the same version string. Run `pnpm verify-version` to check. Update both files before tagging a release.
+
+### Sync quota exceeded
+
+`chrome.storage.sync` has an 8,192-byte total limit. The byte counter in the UI shows current usage. If text approaches the limit, the sync write may silently fail. The throttle logic prevents exceeding write rate limits but does not guard against total size.
+
+### Extension doesn't open / action icon does nothing
+
+Check the service worker status in `chrome://extensions`. If it shows "Inactive" or "Error", inspect the service worker console for errors. Common cause: syntax error in `service_worker.bundle.js` after a bad build.
+
+### Cursor position not restored
+
+Cursor position is stored in `chrome.storage.local`, not sync storage. If local storage is cleared (e.g., extension reinstall), cursor position resets to the start.
+
+## Debugging Tips
+
+- **Service worker logs**: Open `chrome://extensions`, find Write Wall, click "Inspect views: service worker"
+- **UI page logs**: Right-click the Write Wall page, choose "Inspect" to open DevTools
+- **Storage inspection**: In DevTools console, run `chrome.storage.sync.get(null, console.log)` to see all synced data
+- **Throttle behavior**: The throttle is leading-edge; the first call fires immediately, subsequent calls within the delay window are dropped (not queued)


### PR DESCRIPTION
**PR checklist**

- [x] Ensure you have added or ran the appropriate tests for your PR.
- [x] DCO signed

**What type of PR is this?**

Documentation refactoring

**What this PR does / why we need it**:

Refactors project documentation into a structured 3-tier progressive disclosure system optimized for AI coding agents:

- **Tier 1a: AGENTS.md** (universal) - Refactored with tech stack, "where to add code" table, critical constraints, common pitfalls, and cross-references
- **Tier 1b: CLAUDE.md** (new) - Claude-specific extensions: architecture quick reference, code patterns with examples, debugging playbook, CI/CD details
- **Tier 2: docs/KNOWLEDGE_BASE.md** (new) - Table of contents with 1-2 line summaries pointing to detailed docs
- **Tier 3: docs/*.md** (new) - Comprehensive documentation: `architecture.md`, `development.md`, `troubleshooting.md`

**Which issue(s) this PR fixes**:

N/A - documentation improvement

**Special notes for your reviewer**:

- AGENTS.md is 103 lines (under 150-line limit), containing only universal agent instructions
- CLAUDE.md is 48 lines (under 95-line limit), with `@AGENTS.md` import as first line
- KNOWLEDGE_BASE.md is a TOC only (18 lines), no full content
- No changes to source code or tests

**Does this PR introduce a user-facing change?**:

NONE
